### PR TITLE
Default scheduled container block to full width in editor

### DIFF
--- a/block/block.json
+++ b/block/block.json
@@ -14,7 +14,8 @@
     "end": { "type": "string", "default": "" },
     "showForAdmins": { "type": "boolean", "default": true },
     "showPlaceholder": { "type": "boolean", "default": false },
-    "placeholderText": { "type": "string", "default": "" }
+    "placeholderText": { "type": "string", "default": "" },
+    "align": { "type": "string", "default": "full" }
   },
   "supports": {
     "html": false,

--- a/block/editor.js
+++ b/block/editor.js
@@ -8,6 +8,8 @@
     var InspectorControls = be.InspectorControls;
     var InnerBlocks = be.InnerBlocks;
     var BlockControls = be.BlockControls;
+    var useBlockProps = be.useBlockProps;
+    var useInnerBlocksProps = be.useInnerBlocksProps;
 
     var components = wp.components;
     var PanelBody = components.PanelBody;
@@ -74,6 +76,12 @@
                 return 'Start: ' + formatReadable(start) + ' | End: ' + formatReadable(end);
             }
 
+            var blockProps = useBlockProps({ className: 'scb-editor-frame' });
+            var innerBlocksProps = useInnerBlocksProps(
+                { className: 'scb-editor-inner' },
+                { allowedBlocks: ALLOWED_BLOCKS, template: TEMPLATE, templateLock: false }
+            );
+
             return el(
                 Fragment,
                 null,
@@ -129,20 +137,12 @@
                 ),
                 el(
                     'div',
-                    { className: 'scb-editor-frame' },
+                    blockProps,
                     el(Notice, { status: 'info', isDismissible: false },
                         el('strong', null, __('Scheduled Container', 'scheduled-content-block')),
                         ': ' + scheduleLabel()
                     ),
-                    el(
-                        'div',
-                        { className: 'scb-editor-inner' },
-                        el(InnerBlocks, {
-                            allowedBlocks: ALLOWED_BLOCKS,
-                            template: TEMPLATE,
-                            templateLock: false
-                        })
-                    )
+                    el('div', innerBlocksProps)
                 )
             );
         },


### PR DESCRIPTION
## Summary
- Set default `align` attribute to `full` so new blocks span the editor width by default
- Use `useBlockProps` and `useInnerBlocksProps` to apply full-width wrapper and allow inner blocks to set alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87d74ffb88322b8cf966da0b2b56c