### PR TITLE
Improve schedule field layout and labels

### DIFF
--- a/block/editor.css
+++ b/block/editor.css
@@ -9,3 +9,13 @@
   border-radius: 6px;
   background: #fff;
 }
+
+.scb-datetime-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.scb-datetime-row .components-text-control__input {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- rename schedule panel to "Display Schedule" with clearer description
- show start/end date and time fields inline for better alignment
- add styling to align date and time inputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b88ecfedf88322b6c1d99abd091e8f