### PR TITLE
Default start time and update placeholder label

### DIFF
--- a/block/editor.js
+++ b/block/editor.js
@@ -3,6 +3,7 @@
     var __ = wp.i18n.__;
     var el = wp.element.createElement;
     var Fragment = wp.element.Fragment;
+    var useEffect = wp.element.useEffect;
 
     var be = wp.blockEditor || wp.editor;
     var InspectorControls = be.InspectorControls;
@@ -123,6 +124,12 @@
             var showPlaceholder = attributes.showPlaceholder;
             var placeholderText = attributes.placeholderText;
 
+            useEffect(function(){
+                if (!start) {
+                    setAttributes({ start: toISOZ(new Date()) });
+                }
+            }, [start]);
+
             function scheduleLabel() {
                 return 'Start: ' + formatReadable(start) + ' | End: ' + formatReadable(end);
             }
@@ -203,7 +210,7 @@
                             onChange: function (v) { setAttributes({ showForAdmins: !!v }); }
                         }),
                         el(ToggleControl, {
-                            label: __('Output placeholder when hidden', 'scheduled-content-block'),
+                            label: __('Show a placeholder message when hidden', 'scheduled-content-block'),
                             checked: !!showPlaceholder,
                             onChange: function (v) { setAttributes({ showPlaceholder: !!v }); }
                         }),


### PR DESCRIPTION
## Summary
- Set newly created blocks to default their start date/time to the current time
- Rename visibility option to "Show a placeholder message when hidden"

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check block/editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68b89eb6ef0483229bbe819906975705