### PR TITLE
Default start time and update placeholder label

### DIFF
--- a/block/editor.js
+++ b/block/editor.js
@@ -125,10 +125,16 @@
             var placeholderText = attributes.placeholderText;
 
             useEffect(function(){
-                if (!start) {
+                if (
+                    !start &&
+                    !end &&
+                    showForAdmins === true &&
+                    showPlaceholder === false &&
+                    !placeholderText
+                ) {
                     setAttributes({ start: toISOZ(new Date()) });
                 }
-            }, [start]);
+            }, []);
 
             function scheduleLabel() {
                 return 'Start: ' + formatReadable(start) + ' | End: ' + formatReadable(end);


### PR DESCRIPTION
## Summary
- Set newly created blocks to default their start date/time to the current time
- Rename visibility option to "Show a placeholder message when hidden"
- Guard start time initialization so it only runs for newly inserted blocks

## Testing
- `node --check block/editor.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a1fb8cec832292bdac4fe2878f6e