### PR TITLE
Add role visibility controls and default block width

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - Requires at least: 6.0
 - Tested up to: 6.8
 - Requires PHP: 8.2
-- Stable tag: 0.0.6
+- Stable tag: 0.1.0
 - License: GPLv3 or later
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -13,6 +13,7 @@ Scheduled Content Block is a WordPress plugin which enables the easy scheduling 
 ## Features
 - Simple container block, allowing you to display content within the block during a specific timeframe.
 - Optional integration with the Breeze caching plugin, purging the site's cache when content is scheduled to become active or inactive.
+- Global settings to choose which user roles may bypass the schedule.
 
 ## Changelog
 - v0.0.1: Initial alpha release.
@@ -20,4 +21,6 @@ Scheduled Content Block is a WordPress plugin which enables the easy scheduling 
 - v0.0.3: Cleaned up the date/time display in the editor.
 - v0.0.4: Added optional integration to the Breeze cache plugin to purge the cache when content is scheduled to go live and when it is scheduled to be removed.
 - v0.0.5: Testing Codex PRs. What could go wrong? Made the block full-width to allow for flexible widths of content inside the block.
-- v0.0.6: Improved the layout and wording of the schedule field and made some updates to ensure that scheduled times align with the site time. 
+- v0.0.6: Improved the layout and wording of the schedule field and made some updates to ensure that scheduled times align with the site time.
+- v0.0.7: Added per-role visibility settings and made the block default to normal width while supporting wide and full alignments.
+- v0.1.0: Beta release.

--- a/block/block.json
+++ b/block/block.json
@@ -12,10 +12,8 @@
   "attributes": {
     "start": { "type": "string", "default": "" },
     "end": { "type": "string", "default": "" },
-    "showForAdmins": { "type": "boolean", "default": true },
     "showPlaceholder": { "type": "boolean", "default": false },
-    "placeholderText": { "type": "string", "default": "" },
-    "align": { "type": "string", "default": "full" }
+    "placeholderText": { "type": "string", "default": "" }
   },
   "supports": {
     "html": false,
@@ -27,8 +25,7 @@
   "example": {
     "attributes": {
       "start": "2025-09-02T09:00:00Z",
-      "end": "2025-09-10T17:00:00Z",
-      "showForAdmins": true
+      "end": "2025-09-10T17:00:00Z"
     },
     "innerBlocks": [
       {

--- a/block/editor.js
+++ b/block/editor.js
@@ -120,7 +120,6 @@
             var setAttributes = props.setAttributes;
             var start = attributes.start;
             var end = attributes.end;
-            var showForAdmins = attributes.showForAdmins;
             var showPlaceholder = attributes.showPlaceholder;
             var placeholderText = attributes.placeholderText;
 
@@ -204,11 +203,6 @@
                     el(
                         PanelBody,
                         { title: __('Visibility Options', 'scheduled-content-block'), initialOpen: false },
-                        el(ToggleControl, {
-                            label: __('Always show to admins', 'scheduled-content-block'),
-                            checked: !!showForAdmins,
-                            onChange: function (v) { setAttributes({ showForAdmins: !!v }); }
-                        }),
                         el(ToggleControl, {
                             label: __('Show a placeholder message when hidden', 'scheduled-content-block'),
                             checked: !!showPlaceholder,

--- a/block/style.css
+++ b/block/style.css
@@ -1,13 +1,3 @@
-.scb-admin-visible .scb-badge {
-  font: 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  background: #fff7cc;
-  border: 1px solid #f0da7f;
-  color: #7a5b00;
-  padding: 6px 8px;
-  margin-bottom: 8px;
-  border-radius: 4px;
-}
-
 .scb-placeholder {
   min-height: 1rem;
 }


### PR DESCRIPTION
## Summary
- Default block width to normal while retaining wide and full options
- Add settings to choose which roles may view content outside the schedule
- Document new role visibility feature, update changelog, and bump to beta version 0.1.0

## Testing
- `php -l scheduled-content-block.php`
- `node --check block/editor.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9a8e43f7c8322a8457f69c532e516