### PR TITLE
Fix undefined admin check in block editor

### DIFF
--- a/block/editor.js
+++ b/block/editor.js
@@ -127,7 +127,6 @@
                 if (
                     !start &&
                     !end &&
-                    showForAdmins === true &&
                     showPlaceholder === false &&
                     !placeholderText
                 ) {


### PR DESCRIPTION
## Summary
- remove leftover `showForAdmins` reference so the block renders in the editor

## Testing
- `php -l scheduled-content-block.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb8805ec83228b57f5fe92940132