### PR TITLE
Refactor plugin hooks and release v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - Requires at least: 6.0
 - Tested up to: 6.8
 - Requires PHP: 8.2
-- Stable tag: 0.1.2
+- Stable tag: 1.0.0
 - License: GPLv3 or later
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -28,3 +28,4 @@ Scheduled Content Block is a WordPress plugin which enables the easy scheduling 
 - v0.1.0: Beta release.
 - v0.1.1: Fix undefined admin check in block editor.
 - v0.1.2: Adjusted the requires version to be a major release. Added short description. Modified features and long description.
+- v1.0.0: First stable release with internal refactoring.


### PR DESCRIPTION
## Summary
- refactor anonymous WordPress hooks into named functions for maintainability
- bump plugin and documentation to version 1.0.0
- restore Breeze cache clearing by detecting plugin functions and calling them directly

## Testing
- `php -l scheduled-content-block.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb36dd546483229b38fa0d876e1484