### PR TITLE
Fix Breeze cache purge detection and bump version to 1.01

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - Requires at least: 6.0
 - Tested up to: 6.8
 - Requires PHP: 8.2
-- Stable tag: 1.0.0
+- Stable tag: 1.01
 - License: GPLv3 or later
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -29,3 +29,4 @@ Scheduled Content Block is a WordPress plugin which enables the easy scheduling 
 - v0.1.1: Fix undefined admin check in block editor.
 - v0.1.2: Adjusted the requires version to be a major release. Added short description. Modified features and long description.
 - v1.0.0: First stable release with internal refactoring.
+- v1.01: Expand Breeze cache purge detection to include static class methods and fallback hooks.

--- a/scheduled-content-block.php
+++ b/scheduled-content-block.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Scheduled Content Block
  * Description: A simple container block that enables the easy scheduling of content on WordPress pages or posts.
- * Version: 1.0.0
+ * Version: 1.01
  * Requires PHP: 8.2
  * Author: h.b Plugins
  * Author URI: https://hancock.build
@@ -259,25 +259,30 @@ function scb_user_can_bypass_schedule() {
 
 /** Utility: determine if Breeze cache purge facilities are available. */
 function scb_breeze_is_available() {
-        // Breeze may expose either a direct function or an action hook for purging.
+        // Breeze may expose direct functions, a static class method or an action hook.
         return function_exists( 'breeze_clear_all_cache' )
                 || function_exists( 'breeze_cache_flush' )
+                || ( class_exists( 'Breeze_PurgeCache' ) && method_exists( 'Breeze_PurgeCache', 'breeze_cache_flush' ) )
                 || has_action( 'breeze_clear_all_cache' );
 }
 
 /** Utility: purge Breeze caches (site-wide). */
 function scb_breeze_purge_all() {
-        // Prefer direct function calls when available; otherwise fall back to the action hook.
+        // Prefer direct function calls when available; otherwise fall back to class methods or action hooks.
         if ( function_exists( 'breeze_clear_all_cache' ) ) {
                 breeze_clear_all_cache();
         } elseif ( function_exists( 'breeze_cache_flush' ) ) {
                 breeze_cache_flush();
+        } elseif ( class_exists( 'Breeze_PurgeCache' ) && method_exists( 'Breeze_PurgeCache', 'breeze_cache_flush' ) ) {
+                Breeze_PurgeCache::breeze_cache_flush();
         } else {
                 do_action( 'breeze_clear_all_cache' );
         }
         // Optional: also try Varnish module if provided.
         if ( function_exists( 'breeze_clear_varnish' ) ) {
                 breeze_clear_varnish();
+        } elseif ( class_exists( 'Breeze_PurgeCache' ) && method_exists( 'Breeze_PurgeCache', 'breeze_clear_varnish' ) ) {
+                Breeze_PurgeCache::breeze_clear_varnish();
         } elseif ( has_action( 'breeze_clear_varnish' ) ) {
                 do_action( 'breeze_clear_varnish' );
         }


### PR DESCRIPTION
## Summary
- expand Breeze plugin detection to include static class methods
- purge Breeze and Varnish caches using class fallbacks when global functions are absent
- bump plugin and documentation to version 1.01

## Testing
- `php -l scheduled-content-block.php`


------
https://chatgpt.com/codex/tasks/task_e_68c057ff50ec83229d117d3f64d810f6