### PR TITLE
Add WordPress plugin readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,51 @@
+=== Scheduled Content Block ===
+Contributors: hancockbuild
+Requires at least: 6.0
+Tested up to: 6.8
+Requires PHP: 8.2
+Stable tag: 0.1.2
+License: GPLv3 or later
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
+
+Scheduled Content Block makes creating scheduled content within blocks simple and completely hands-free.
+
+== Description ==
+Scheduled Content Block is a WordPress plugin that enables easy scheduling of content on WordPress pages or posts via a Scheduled Content block. Add a Scheduled Container block, fill it with the content you'd like, set the schedule, and publish your post or page. The content you create inside the block will only be visible during its scheduled time.
+
+== Features ==
+* Simple container block, allowing you to display content within the block during a specific timeframe.
+* Optional integration with the Breeze caching plugin, purging the site's cache when content is scheduled to become active or inactive.
+* Change who is able to see scheduled content on your site with role-based controls.
+
+== Changelog ==
+= 0.1.2 =
+* Adjusted the required version to be a major release.
+* Added short description.
+* Modified features and long description.
+
+= 0.1.1 =
+* Fix undefined admin check in block editor.
+
+= 0.1.0 =
+* Beta release.
+
+= 0.0.7 =
+* Added per-role visibility settings and made the block default to normal width while supporting wide and full alignments.
+
+= 0.0.6 =
+* Improved the layout and wording of the schedule field and made updates to ensure scheduled times align with the site time.
+
+= 0.0.5 =
+* Made the block full-width to allow for flexible widths of content inside the block.
+
+= 0.0.4 =
+* Added optional integration to the Breeze cache plugin to purge the cache when content is scheduled to go live and when it is scheduled to be removed.
+
+= 0.0.3 =
+* Cleaned up the date/time display in the editor.
+
+= 0.0.2 =
+* Fixed issue with the scheduled date/time not lining up with the set local time on WordPress.
+
+= 0.0.1 =
+* Initial alpha release.


### PR DESCRIPTION
## Summary
- add a readme.txt formatted for the WordPress plugin directory
- document plugin description, features, and changelog entries with directory markup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd94fba1448322999c1ac0c3f085c8