### PR TITLE
Release version 1.0.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hancockbuild
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 0.1.2
+Stable tag: 1.0.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -18,6 +18,9 @@ Scheduled Content Block is a WordPress plugin that enables easy scheduling of co
 * Change who is able to see scheduled content on your site with role-based controls.
 
 == Changelog ==
+= 1.0.0 =
+* First stable release following successful Plugin Check validation.
+
 = 0.1.2 =
 * Adjusted the required version to be a major release.
 * Added short description.

--- a/scheduled-content-block.php
+++ b/scheduled-content-block.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Scheduled Content Block
  * Description: A simple container block that enables the easy scheduleing of content on WordPress pages or posts.
- * Version: 0.1.2
+ * Version: 1.0.0
  * Requires PHP: 8.2
  * Author: h.b Plugins
  * Author URI: https://hancock.build


### PR DESCRIPTION
## Summary
- bump the plugin header version to 1.0.0 for the stable release
- update the readme stable tag and changelog to reflect the 1.0.0 release and plugin check success

## Testing
- php -l scheduled-content-block.php

------
https://chatgpt.com/codex/tasks/task_e_68cda058fa788322ad60b83e4e6764a7